### PR TITLE
Save values of all export properties

### DIFF
--- a/io_scene_nif/modules/object/object_export.py
+++ b/io_scene_nif/modules/object/object_export.py
@@ -48,8 +48,7 @@ from io_scene_nif.utility.nif_logging import NifLog
 
 # JMQTODO:
 # settings:
-# - save other export settings
-# - button to reset settings to default and reset for selected game
+# - button to reset settings for selected game?
 # - figure out a sane way to deal with scale
 # - button for triangulate
 # - button for apply modifiers

--- a/io_scene_nif/operators/kf_export_op.py
+++ b/io_scene_nif/operators/kf_export_op.py
@@ -79,7 +79,7 @@ class KfExportOperator(bpy.types.Operator, ExportHelper, NifOperatorCommon):
             ],
         name="Game",
         description="For which game to export.",
-        default='FALLOUT_3')
+        default='OBLIVION')
 
     #: Use BSAnimationNode (for Morrowind).
     bs_animation_node = bpy.props.BoolProperty(


### PR DESCRIPTION
- The blend file must actually be saved after a successful export for the settings to be saved.
- Also add restore defaults button.
